### PR TITLE
fix: allow map continuations to return generators

### DIFF
--- a/src/pfun/effect.pyx
+++ b/src/pfun/effect.pyx
@@ -849,9 +849,10 @@ cdef class Map(CEffect):
     
     async def resume(self, RuntimeEnv env):
         async def g(x):
-            result = self.continuation(x)
-            if asyncio.iscoroutine(result):
-                result = await result
+            if asyncio.iscoroutinefunction(self.continuation):
+                result = await self.continuation(x)
+            else:
+                result = self.continuation(x)
             return CSuccess.__new__(CSuccess, result)
         return await self.effect.apply_continuation(g, env)
     

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -526,6 +526,12 @@ class TestEffect(MonadTest):
         assert (repr(effect.success(0).timeout(timedelta(seconds=1))) ==
                 'success(0).timeout(datetime.timedelta(seconds=1))')
 
+    def test_map_generator(self):
+        def f(_):
+            yield from [1, 2, 3]
+
+        assert list(effect.success(None).map(f).run(None)) == [1, 2, 3]
+
 
 class TestResource:
     def test_get(self):


### PR DESCRIPTION
closes #112 