### PR TITLE
fix: deduplicate typevars in intersection hook

### DIFF
--- a/src/pfun/mypy_plugin.py
+++ b/src/pfun/mypy_plugin.py
@@ -86,8 +86,6 @@ class TranslateIntersection(TypeTranslator):
                            f'must be protocols, but got "{s}"')
                 self.api.msg.fail(msg, self.context)
                 return AnyType(TypeOfAny.special_form)
-            if not has_no_typevars(t):
-                return t
             bases = []
             for arg in args:
                 if arg in bases:
@@ -95,6 +93,8 @@ class TranslateIntersection(TypeTranslator):
                 bases.extend(self.get_bases(arg, []))
             if len(bases) == 1:
                 return bases[0]
+            if not has_no_typevars(t):
+                return t
             bases_repr = ', '.join([repr(base) for base in bases])
             name = f'Intersection[{bases_repr}]'
             defn = ClassDef(

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -268,6 +268,7 @@ class TestEffect(MonadTest):
     def test_catch_cpu_bound(self, f):
         assert effect.catch_cpu_bound(Exception)(f)(None).run(None) == f(None)
 
+    @settings(deadline=None)
     @given(unaries(anything()))
     def test_catch_io_bound(self, f):
         assert effect.catch_io_bound(Exception)(f)(None).run(None) == f(None)

--- a/tests/test_mypy_plugin.yaml
+++ b/tests/test_mypy_plugin.yaml
@@ -679,3 +679,14 @@
     reveal_type(c3.f(a3, b3)) # N: Revealed type is "pfun.Intersection[main.P2, main.P3, main.P1]"
 
     c1.f(a4, b4) # E: All arguments to "Intersection" must be protocols but inferred "pfun.Intersection[builtins.object, builtins.str, main.P1]"
+- case: "intersection_deduplicates_typevars"
+  disable_cache: true
+  main: |
+    from typing import TypeVar, Callable
+
+    from pfun import Depends
+
+    R = TypeVar('R')
+
+    def f(d1: Depends[R, int], d2: Callable[[int], Depends[R, str]]) -> Depends[R, str]:
+        return reveal_type(d1.and_then(d2))  # N: Revealed type is "pfun.effect.Effect[R`-1, <nothing>, builtins.str]"


### PR DESCRIPTION
closes #111 