### PR TITLE
Fix error in docs

### DIFF
--- a/src/pfun/__init__.py
+++ b/src/pfun/__init__.py
@@ -49,7 +49,7 @@ class DefaultModules:
 
     Example:
         >>> from pfun import console, random, DefaultModules
-        >>> random.random().and_then(console.print).run(DefaultModules())
+        >>> random.random().and_then(console.print_line).run(DefaultModules())
         0.51351531
     Attributes:
         files: The files module


### PR DESCRIPTION
Getting this error before the fix:
    AttributeError: module 'pfun.console' has no attribute 'print'